### PR TITLE
Add Company endpoint and refactor ApiUrls to support custom base URLs

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -11,10 +11,12 @@
   - [Basic](#basic)
   - [Bulk](#bulk)
   - [Carrier](#carrier)
+  - [Company](#company)
   - [Asn](#asn)
   - [Timezone](#timezone)
   - [Currency](#currency)
   - [Threat](#threat)
+- [EU Endpoint](#eu-endpoint)
 - [Contributing](#contributing)
 - [Versioning](#versioning)
 - [License](#license)
@@ -83,6 +85,15 @@ var carrierInfo = await client.Carrier("69.78.70.144");
 Console.WriteLine($"Carrier name: {carrierInfo.Name}");
 ```
 
+### Company
+
+```csharp
+var client = new IpDataClient("API_KEY");
+
+var companyInfo = await client.Company("69.78.70.144");
+Console.WriteLine($"Company name: {companyInfo.Name}");
+```
+
 ### ASN
 
 ```csharp
@@ -117,6 +128,16 @@ var client = new IpDataClient("API_KEY");
 
 var threatInfo = await client.Threat("69.78.70.144");
 Console.WriteLine($"Threat is Tor: {threatInfo.IsTor}");
+```
+
+## EU Endpoint
+
+To ensure your data stays in the EU, use the EU endpoint by passing a custom base URL:
+
+```csharp
+var client = new IpDataClient("API_KEY", new Uri("https://eu-api.ipdata.co"));
+
+var ipInfo = await client.Lookup("8.8.8.8");
 ```
 
 ## Contributing

--- a/samples/IpData.Lookup/IpData.Lookup.csproj
+++ b/samples/IpData.Lookup/IpData.Lookup.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
     <LangVersion>latest</LangVersion>

--- a/src/IpData/Helpers/ApiUrls.cs
+++ b/src/IpData/Helpers/ApiUrls.cs
@@ -51,6 +51,9 @@ namespace IpData.Helpers
         public static Uri Threat(string apiKey, string ip) =>
             ApplyApiKey(new Uri(Base, $"{ip}/threat"), apiKey);
 
+        public static Uri Company(string apiKey, string ip) =>
+            ApplyApiKey(new Uri(Base, $"{ip}/company"), apiKey);
+
         private static Uri ApplyApiKey(Uri url, string apiKey) =>
             url.AddParameter("api-key", apiKey);
     }

--- a/src/IpData/Helpers/ApiUrls.cs
+++ b/src/IpData/Helpers/ApiUrls.cs
@@ -8,51 +8,58 @@ using IpData.Models;
 
 namespace IpData.Helpers
 {
-    internal static class ApiUrls
+    internal class ApiUrls
     {
-        private static Uri Base => new Uri("https://api.ipdata.co");
+        internal static readonly Uri DefaultBaseUrl = new Uri("https://api.ipdata.co");
 
-        public static Uri Get(string apiKey, CultureInfo culture) =>
-            ApplyApiKey(new Uri(Base, $"{culture}"), apiKey);
+        private readonly Uri _base;
 
-        public static Uri Get(string apiKey, string ip, CultureInfo culture)
+        public ApiUrls(Uri baseUrl = null)
+        {
+            _base = baseUrl ?? DefaultBaseUrl;
+        }
+
+        public Uri Get(string apiKey, CultureInfo culture) =>
+            ApplyApiKey(new Uri(_base, $"{culture}"), apiKey);
+
+        public Uri Get(string apiKey, string ip, CultureInfo culture)
         {
             var relative = Equals(culture, CultureInfo.InvariantCulture) ? ip : $"{ip}/{culture}";
-            return ApplyApiKey(new Uri(Base, relative), apiKey);
+            return ApplyApiKey(new Uri(_base, relative), apiKey);
         }
 
-        public static Uri Get(string apiKey, string ip, Expression<Func<IpInfo, object>> expression)
+        public Uri Get(string apiKey, string ip, Expression<Func<IpInfo, object>> expression)
         {
             var field = IpInfo.FieldName(expression);
-            return ApplyApiKey(new Uri(Base, $"{ip}/{field}"), apiKey);
+            return ApplyApiKey(new Uri(_base, $"{ip}/{field}"), apiKey);
         }
-        
-        public static Uri Get(string apiKey, string ip, params Expression<Func<IpInfo, object>>[] expressions)
+
+        public Uri Get(string apiKey, string ip, params Expression<Func<IpInfo, object>>[] expressions)
         {
             var fields = string.Join(",", expressions.Select(IpInfo.FieldName));
-            return ApplyApiKey(new Uri(Base, $"{ip}").AddParameter(nameof(fields), fields), apiKey);
+            return ApplyApiKey(new Uri(_base, $"{ip}").AddParameter(nameof(fields), fields), apiKey);
         }
 
-        public static Uri Bulk(string apiKey) =>
-            ApplyApiKey(new Uri(Base, "bulk"), apiKey);
+        public Uri Bulk(string apiKey) =>
+            ApplyApiKey(new Uri(_base, "bulk"), apiKey);
 
-        public static Uri Carrier(string apiKey, string ip) =>
-            ApplyApiKey(new Uri(Base, $"{ip}/carrier"), apiKey);
+        public Uri Carrier(string apiKey, string ip) =>
+            ApplyApiKey(new Uri(_base, $"{ip}/carrier"), apiKey);
 
-        public static Uri Asn(string apiKey, string ip) =>
-            ApplyApiKey(new Uri(Base, $"asn/{ip}"), apiKey);
+        public Uri Asn(string apiKey, string ip) =>
+            ApplyApiKey(new Uri(_base, $"asn/{ip}"), apiKey);
 
-        public static Uri TimeZone(string apiKey, string ip) =>
-            ApplyApiKey(new Uri(Base, $"{ip}/time_zone"), apiKey);
+        public Uri TimeZone(string apiKey, string ip) =>
+            ApplyApiKey(new Uri(_base, $"{ip}/time_zone"), apiKey);
 
-        public static Uri Currency(string apiKey, string ip) =>
-            ApplyApiKey(new Uri(Base, $"{ip}/currency"), apiKey);
+        public Uri Currency(string apiKey, string ip) =>
+            ApplyApiKey(new Uri(_base, $"{ip}/currency"), apiKey);
 
-        public static Uri Threat(string apiKey, string ip) =>
-            ApplyApiKey(new Uri(Base, $"{ip}/threat"), apiKey);
+        public Uri Threat(string apiKey, string ip) =>
+            ApplyApiKey(new Uri(_base, $"{ip}/threat"), apiKey);
 
-        public static Uri Company(string apiKey, string ip) =>
-            ApplyApiKey(new Uri(Base, $"{ip}/company"), apiKey);
+        public Uri Company(string apiKey, string ip) =>
+            ApplyApiKey(new Uri(_base, $"{ip}/company"), apiKey);
 
         private static Uri ApplyApiKey(Uri url, string apiKey) =>
             url.AddParameter("api-key", apiKey);

--- a/src/IpData/Helpers/ApiUrls.cs
+++ b/src/IpData/Helpers/ApiUrls.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;

--- a/src/IpData/IIpDataClient.cs
+++ b/src/IpData/IIpDataClient.cs
@@ -13,6 +13,23 @@ namespace IpData
         /// <summary>The IpData ApiKey.</summary>
         string ApiKey { get; }
 
+        /// <summary>Fetch company for IP.</summary>
+        /// <param name="ip">The IPv4 address.</param>
+        /// <returns>The company info <see cref="CompanyInfo"/>.</returns>
+        /// <exception cref="Exceptions.BadRequestException">
+        /// Thrown when IP address is private or invalid.
+        /// </exception>
+        /// <exception cref="Exceptions.ForbiddenException">
+        /// Thrown when you have exceeded your daily plan quota.
+        /// </exception>
+        /// <exception cref="Exceptions.UnauthorizedException">
+        /// Thrown when API key is not provided.
+        /// </exception>
+        /// <exception cref="Exceptions.ApiException">
+        /// Thrown when unexpected case occurred.
+        /// </exception>
+        Task<CompanyInfo> Company(string ip);
+
         /// <summary>Fetch carrier for IP.</summary>
         /// <param name="ip">The IPv4 address.</param>
         /// <returns>The carrier info <see cref="CarrierInfo"/>.</returns>

--- a/src/IpData/IpDataClient.cs
+++ b/src/IpData/IpDataClient.cs
@@ -122,6 +122,15 @@ namespace IpData
         }
 
         /// <inheritdoc />
+        public async Task<CompanyInfo> Company(string ip)
+        {
+            var url = ApiUrls.Company(ApiKey, ip);
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
+            return _serializer.Deserialize<CompanyInfo>(json);
+        }
+
+        /// <inheritdoc />
         public async Task<CarrierInfo> Carrier(string ip)
         {
             var url = ApiUrls.Carrier(ApiKey, ip);

--- a/src/IpData/IpDataClient.cs
+++ b/src/IpData/IpDataClient.cs
@@ -26,13 +26,16 @@ namespace IpData
         /// <summary>The HTTP client</summary>
         private readonly IHttpClient _httpClient;
 
+        /// <summary>The API URL builder</summary>
+        private readonly ApiUrls _apiUrls;
+
         /// <inheritdoc />
         public string ApiKey { get; }
 
         /// <summary>Initializes a new instance of the <see cref="IpDataClient"/> class.</summary>
         /// <param name="apiKey">The API key.</param>
         public IpDataClient(string apiKey)
-            : this(apiKey, new HttpClientAdapter())
+            : this(apiKey, new HttpClientAdapter(), null)
         {
         }
 
@@ -40,16 +43,33 @@ namespace IpData
         /// <param name="apiKey">The API key.</param>
         /// <param name="httpClient">The HTTP client.</param>
         public IpDataClient(string apiKey, HttpClient httpClient)
-            : this(apiKey, new HttpClientAdapter(httpClient))
+            : this(apiKey, new HttpClientAdapter(httpClient), null)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="IpDataClient"/> class.</summary>
         /// <param name="apiKey">The API key.</param>
         /// <param name="httpClient">The HTTP client.</param>
+        public IpDataClient(string apiKey, IHttpClient httpClient)
+            : this(apiKey, httpClient, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="IpDataClient"/> class with a custom base URL.</summary>
+        /// <param name="apiKey">The API key.</param>
+        /// <param name="baseUrl">The base URL (e.g. https://eu-api.ipdata.co for the EU endpoint).</param>
+        public IpDataClient(string apiKey, Uri baseUrl)
+            : this(apiKey, new HttpClientAdapter(), baseUrl)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="IpDataClient"/> class.</summary>
+        /// <param name="apiKey">The API key.</param>
+        /// <param name="httpClient">The HTTP client.</param>
+        /// <param name="baseUrl">The base URL. Defaults to https://api.ipdata.co when null.</param>
         /// <exception cref="ArgumentException">The {nameof(apiKey)} {apiKey} - apiKey</exception>
         /// <exception cref="ArgumentNullException">httpClient - The {nameof(httpClient)}</exception>
-        public IpDataClient(string apiKey, IHttpClient httpClient)
+        public IpDataClient(string apiKey, IHttpClient httpClient, Uri baseUrl)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
             {
@@ -63,6 +83,7 @@ namespace IpData
                 $"The {nameof(httpClient)} can't be null");
 
             ApiKey = apiKey;
+            _apiUrls = new ApiUrls(baseUrl);
         }
 
         /// <inheritdoc />
@@ -72,7 +93,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<IpInfo> Lookup(CultureInfo culture)
         {
-            var url = ApiUrls.Get(ApiKey, culture);
+            var url = _apiUrls.Get(ApiKey, culture);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<IpInfo>(json);
@@ -85,7 +106,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<IpInfo> Lookup(string ip, CultureInfo culture)
         {
-            var url = ApiUrls.Get(ApiKey, ip, culture);
+            var url = _apiUrls.Get(ApiKey, ip, culture);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<IpInfo>(json);
@@ -94,7 +115,7 @@ namespace IpData
         /// <inheritdoc />
         public Task<string> Lookup(string ip, Expression<Func<IpInfo, object>> fieldSelector)
         {
-            var url = ApiUrls.Get(ApiKey, ip, fieldSelector);
+            var url = _apiUrls.Get(ApiKey, ip, fieldSelector);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             return SendRequestAsync(_httpClient, request);
         }
@@ -102,7 +123,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<IpInfo> Lookup(string ip, params Expression<Func<IpInfo, object>>[] fieldSelectors)
         {
-            var url = ApiUrls.Get(ApiKey, ip, fieldSelectors);
+            var url = _apiUrls.Get(ApiKey, ip, fieldSelectors);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<IpInfo>(json);
@@ -111,7 +132,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<IEnumerable<IpInfo>> Lookup(IReadOnlyCollection<string> ips)
         {
-            var url = ApiUrls.Bulk(ApiKey);
+            var url = _apiUrls.Bulk(ApiKey);
             var request = new HttpRequestMessage(HttpMethod.Post, url)
             {
                 Content = new StringContent(_serializer.Serialize(ips), Encoding.UTF8, "application/json")
@@ -124,7 +145,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<CompanyInfo> Company(string ip)
         {
-            var url = ApiUrls.Company(ApiKey, ip);
+            var url = _apiUrls.Company(ApiKey, ip);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<CompanyInfo>(json);
@@ -133,7 +154,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<CarrierInfo> Carrier(string ip)
         {
-            var url = ApiUrls.Carrier(ApiKey, ip);
+            var url = _apiUrls.Carrier(ApiKey, ip);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<CarrierInfo>(json);
@@ -142,7 +163,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<AsnInfo> Asn(string ip)
         {
-            var url = ApiUrls.Asn(ApiKey, ip);
+            var url = _apiUrls.Asn(ApiKey, ip);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<AsnInfo>(json);
@@ -151,7 +172,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<Models.TimeZone> TimeZone(string ip)
         {
-            var url = ApiUrls.TimeZone(ApiKey, ip);
+            var url = _apiUrls.TimeZone(ApiKey, ip);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<Models.TimeZone>(json);
@@ -160,7 +181,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<Currency> Currency(string ip)
         {
-            var url = ApiUrls.Currency(ApiKey, ip);
+            var url = _apiUrls.Currency(ApiKey, ip);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<Currency>(json);
@@ -169,7 +190,7 @@ namespace IpData
         /// <inheritdoc />
         public async Task<Threat> Threat(string ip)
         {
-            var url = ApiUrls.Threat(ApiKey, ip);
+            var url = _apiUrls.Threat(ApiKey, ip);
             var request = new HttpRequestMessage(HttpMethod.Get, url);
             var json = await SendRequestAsync(_httpClient, request).ConfigureAwait(false);
             return _serializer.Deserialize<Threat>(json);

--- a/src/IpData/Models/BlocklistInfo.cs
+++ b/src/IpData/Models/BlocklistInfo.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace IpData.Models
+{
+    public class BlocklistInfo
+    {
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [JsonProperty("site", NullValueHandling = NullValueHandling.Ignore)]
+        public string Site { get; set; }
+
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
+        public string Type { get; set; }
+    }
+}

--- a/src/IpData/Models/CompanyInfo.cs
+++ b/src/IpData/Models/CompanyInfo.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace IpData.Models
+{
+    public class CompanyInfo
+    {
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        [JsonProperty("domain", NullValueHandling = NullValueHandling.Ignore)]
+        public string Domain { get; set; }
+
+        [JsonProperty("network", NullValueHandling = NullValueHandling.Ignore)]
+        public string Network { get; set; }
+
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
+        public string Type { get; set; }
+    }
+}

--- a/src/IpData/Models/IpInfo.cs
+++ b/src/IpData/Models/IpInfo.cs
@@ -75,6 +75,18 @@ namespace IpData.Models
         [JsonProperty("threat")]
         public Threat Threat { get; set; }
 
+        [JsonProperty("region_type", NullValueHandling = NullValueHandling.Ignore)]
+        public string RegionType { get; set; }
+
+        [JsonProperty("carrier", NullValueHandling = NullValueHandling.Ignore)]
+        public CarrierInfo Carrier { get; set; }
+
+        [JsonProperty("company", NullValueHandling = NullValueHandling.Ignore)]
+        public CompanyInfo Company { get; set; }
+
+        [JsonProperty("status", NullValueHandling = NullValueHandling.Ignore)]
+        public int? Status { get; set; }
+
         [JsonProperty("count")]
         public int Count { get; set; }
 

--- a/src/IpData/Models/Language.cs
+++ b/src/IpData/Models/Language.cs
@@ -9,5 +9,8 @@ namespace IpData.Models
 
         [JsonProperty("native", NullValueHandling = NullValueHandling.Ignore)]
         public string Native { get; set; }
+
+        [JsonProperty("code", NullValueHandling = NullValueHandling.Ignore)]
+        public string Code { get; set; }
     }
 }

--- a/src/IpData/Models/Threat.cs
+++ b/src/IpData/Models/Threat.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace IpData.Models
 {
@@ -24,5 +25,14 @@ namespace IpData.Models
 
         [JsonProperty("is_bogon", NullValueHandling = NullValueHandling.Ignore)]
         public bool? IsBogon { get; set; }
+
+        [JsonProperty("is_icloud_relay", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsIcloudRelay { get; set; }
+
+        [JsonProperty("is_datacenter", NullValueHandling = NullValueHandling.Ignore)]
+        public bool? IsDatacenter { get; set; }
+
+        [JsonProperty("blocklists")]
+        public List<BlocklistInfo> Blocklists { get; private set; } = new List<BlocklistInfo>();
     }
 }

--- a/test/Unit/IpData.Tests/DataSources/TestDataSource.cs
+++ b/test/Unit/IpData.Tests/DataSources/TestDataSource.cs
@@ -13,12 +13,17 @@ namespace IpData.Tests.DataSources
 
         public static IEnumerable<object[]> IpInfoData()
         {
-            yield return new object[] { "{\"ip\":\"91.225.201.108\",\"is_eu\":false,\"city\":\"Lviv\",\"region\":\"L'vivs'ka Oblast'\",\"region_code\":\"46\",\"country_name\":\"Ukraine\",\"country_code\":\"UA\",\"continent_name\":\"Europe\",\"continent_code\":\"EU\",\"latitude\":49.8486,\"longitude\":24.0323,\"postal\":\"79000\",\"calling_code\":\"380\",\"flag\":\"https:\\/\\/ipdata.co\\/flags\\/ua.png\",\"emoji_flag\":\"\uD83C\uDDFA\uD83C\uDDE6\",\"emoji_unicode\":\"U+1F1FA U+1F1E6\",\"asn\":{\"asn\":\"AS49824\",\"name\":\"PC \\\"Astra-net\\\"\",\"domain\":\"astra.in.ua\",\"route\":\"91.225.200.0\\/22\",\"type\":\"isp\"},\"languages\":[{\"name\":\"Ukrainian\",\"native\":\"\u0423\u043A\u0440\u0430\u0457\u043D\u0441\u044C\u043A\u0430\"}],\"currency\":{\"name\":\"Ukrainian Hryvnia\",\"code\":\"UAH\",\"symbol\":\"\u20B4\",\"native\":\"\u20B4\",\"plural\":\"Ukrainian hryvnias\"},\"time_zone\":{\"name\":\"Europe\\/Kiev\",\"abbr\":\"EET\",\"offset\":\"+0200\",\"is_dst\":false,\"current_time\":\"2020-01-30T23:16:19.129316+02:00\"},\"threat\":{\"is_tor\":false,\"is_proxy\":false,\"is_anonymous\":false,\"is_known_attacker\":false,\"is_known_abuser\":false,\"is_threat\":false,\"is_bogon\":false}}" };
+            yield return new object[] { "{\"ip\":\"91.225.201.108\",\"is_eu\":false,\"city\":\"Lviv\",\"region\":\"L'vivs'ka Oblast'\",\"region_code\":\"46\",\"region_type\":\"oblast\",\"country_name\":\"Ukraine\",\"country_code\":\"UA\",\"continent_name\":\"Europe\",\"continent_code\":\"EU\",\"latitude\":49.8486,\"longitude\":24.0323,\"postal\":\"79000\",\"calling_code\":\"380\",\"flag\":\"https:\\/\\/ipdata.co\\/flags\\/ua.png\",\"emoji_flag\":\"\uD83C\uDDFA\uD83C\uDDE6\",\"emoji_unicode\":\"U+1F1FA U+1F1E6\",\"asn\":{\"asn\":\"AS49824\",\"name\":\"PC \\\"Astra-net\\\"\",\"domain\":\"astra.in.ua\",\"route\":\"91.225.200.0\\/22\",\"type\":\"isp\"},\"company\":{\"name\":\"Astra-net\",\"domain\":\"astra.in.ua\",\"network\":\"91.225.200.0\\/22\",\"type\":\"isp\"},\"carrier\":{\"name\":\"Kyivstar\",\"mcc\":\"255\",\"mnc\":\"03\"},\"languages\":[{\"name\":\"Ukrainian\",\"native\":\"\u0423\u043A\u0440\u0430\u0457\u043D\u0441\u044C\u043A\u0430\",\"code\":\"uk\"}],\"currency\":{\"name\":\"Ukrainian Hryvnia\",\"code\":\"UAH\",\"symbol\":\"\u20B4\",\"native\":\"\u20B4\",\"plural\":\"Ukrainian hryvnias\"},\"time_zone\":{\"name\":\"Europe\\/Kiev\",\"abbr\":\"EET\",\"offset\":\"+0200\",\"is_dst\":false,\"current_time\":\"2020-01-30T23:16:19.129316+02:00\"},\"threat\":{\"is_tor\":false,\"is_icloud_relay\":false,\"is_proxy\":false,\"is_datacenter\":false,\"is_anonymous\":false,\"is_known_attacker\":false,\"is_known_abuser\":false,\"is_threat\":false,\"is_bogon\":false,\"blocklists\":[]},\"status\":200}" };
         }
 
         public static IEnumerable<object[]> CarrierData()
         {
             yield return new object[] { "{\"name\":\"T-Mobile\",\"mcc\":\"310\",\"mnc\":\"160\"\r\n}" };
+        }
+
+        public static IEnumerable<object[]> CompanyData()
+        {
+            yield return new object[] { "{\"name\":\"Google LLC\",\"domain\":\"google.com\",\"network\":\"8.8.8.0\\/24\",\"type\":\"business\"}" };
         }
     }
 }

--- a/test/Unit/IpData.Tests/Helpers/ApiUrlsTests.cs
+++ b/test/Unit/IpData.Tests/Helpers/ApiUrlsTests.cs
@@ -16,7 +16,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Get(apiKey, CultureInfo.InvariantCulture);
+            var url = new ApiUrls().Get(apiKey, CultureInfo.InvariantCulture);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -29,7 +29,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{culture}?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Get(apiKey, culture);
+            var url = new ApiUrls().Get(apiKey, culture);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -42,7 +42,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Get(apiKey, ip, CultureInfo.InvariantCulture);
+            var url = new ApiUrls().Get(apiKey, ip, CultureInfo.InvariantCulture);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -56,7 +56,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/{culture}?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Get(apiKey, ip, culture);
+            var url = new ApiUrls().Get(apiKey, ip, culture);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -69,7 +69,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/count?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Get(apiKey, ip, x => x.Count);
+            var url = new ApiUrls().Get(apiKey, ip, x => x.Count);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -82,7 +82,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/continent_name?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Get(apiKey, ip, x => x.ContinentName);
+            var url = new ApiUrls().Get(apiKey, ip, x => x.ContinentName);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -95,7 +95,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = new Uri($"https://api.ipdata.co/{ip}?fields=country_name%2ccity&api-key={apiKey}");
 
             // Act
-            var url = ApiUrls.Get(apiKey, ip, x => x.CountryName, x => x.City);
+            var url = new ApiUrls().Get(apiKey, ip, x => x.CountryName, x => x.City);
 
             // Assert
             url.Should().BeEquivalentTo(expectedUrl);
@@ -105,7 +105,7 @@ namespace IpData.Tests.Helpers
         public void Get_WhenCalledWithInvalidProp_ReturnedUrl(string apiKey, string ip)
         {
             // Arrange
-            Func<Uri> act = () => ApiUrls.Get(apiKey, ip, x => new { prop = "name" });
+            Func<Uri> act = () => new ApiUrls().Get(apiKey, ip, x => new { prop = "name" });
 
             // Act/Assert
             act.Should()
@@ -120,7 +120,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/bulk?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Bulk(apiKey);
+            var url = new ApiUrls().Bulk(apiKey);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -133,7 +133,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/carrier?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Carrier(apiKey, ip);
+            var url = new ApiUrls().Carrier(apiKey, ip);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -146,7 +146,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/asn/{ip}?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Asn(apiKey, ip);
+            var url = new ApiUrls().Asn(apiKey, ip);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -159,7 +159,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/time_zone?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.TimeZone(apiKey, ip);
+            var url = new ApiUrls().TimeZone(apiKey, ip);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -172,7 +172,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/currency?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Currency(apiKey, ip);
+            var url = new ApiUrls().Currency(apiKey, ip);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -185,7 +185,7 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/threat?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Threat(apiKey, ip);
+            var url = new ApiUrls().Threat(apiKey, ip);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
@@ -198,10 +198,35 @@ namespace IpData.Tests.Helpers
             var expectedUrl = $"https://api.ipdata.co/{ip}/company?api-key={apiKey}";
 
             // Act
-            var url = ApiUrls.Company(apiKey, ip);
+            var url = new ApiUrls().Company(apiKey, ip);
 
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
+        }
+
+        [Theory, AutoMoqData]
+        public void Get_WhenCalledWithCustomBaseUrl_ReturnedUrl(string apiKey, string ip)
+        {
+            // Arrange
+            var euBaseUrl = new Uri("https://eu-api.ipdata.co");
+            var expectedUrl = $"https://eu-api.ipdata.co/{ip}?api-key={apiKey}";
+
+            // Act
+            var url = new ApiUrls(euBaseUrl).Get(apiKey, ip, CultureInfo.InvariantCulture);
+
+            // Assert
+            url.AbsoluteUri.Should().Be(expectedUrl);
+        }
+
+        [Fact]
+        public void DefaultConstructor_UsesDefaultBaseUrl()
+        {
+            // Arrange/Act
+            var sut = new ApiUrls();
+            var url = sut.Bulk("test-key");
+
+            // Assert
+            url.AbsoluteUri.Should().StartWith("https://api.ipdata.co/");
         }
     }
 }

--- a/test/Unit/IpData.Tests/Helpers/ApiUrlsTests.cs
+++ b/test/Unit/IpData.Tests/Helpers/ApiUrlsTests.cs
@@ -190,5 +190,18 @@ namespace IpData.Tests.Helpers
             // Assert
             url.AbsoluteUri.Should().Be(expectedUrl);
         }
+
+        [Theory, AutoMoqData]
+        public void Company_WhenCalled_ReturnedUrl(string apiKey, string ip)
+        {
+            // Arrange
+            var expectedUrl = $"https://api.ipdata.co/{ip}/company?api-key={apiKey}";
+
+            // Act
+            var url = ApiUrls.Company(apiKey, ip);
+
+            // Assert
+            url.AbsoluteUri.Should().Be(expectedUrl);
+        }
     }
 }

--- a/test/Unit/IpData.Tests/Http/Serializer/JsonSerializerTests.cs
+++ b/test/Unit/IpData.Tests/Http/Serializer/JsonSerializerTests.cs
@@ -51,5 +51,26 @@ namespace IpData.Tests.Http.Serializer
             // Assert
             actual.Should().NotBeEmpty();
         }
+
+        [Theory]
+        [MemberData(nameof(TestDataSource.CompanyData), MemberType = typeof(TestDataSource))]
+        public void Deserialize_WhenCalled_ReturnedCompanyInfo(string json)
+        {
+            // Act
+            var actual = _sut.Deserialize<CompanyInfo>(json);
+
+            // Assert
+            actual.Should().NotBeNull();
+        }
+
+        [Theory, AutoMoqData]
+        public void SerializeCompanyInfo_WhenCalled_ReturnedString(CompanyInfo companyInfo)
+        {
+            // Act
+            var actual = _sut.Serialize(companyInfo);
+
+            // Assert
+            actual.Should().NotBeEmpty();
+        }
     }
 }

--- a/test/Unit/IpData.Tests/IpData.Tests.csproj
+++ b/test/Unit/IpData.Tests/IpData.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/test/Unit/IpData.Tests/IpDataClientTests.cs
+++ b/test/Unit/IpData.Tests/IpDataClientTests.cs
@@ -450,6 +450,82 @@ namespace IpData.Tests
         }
 
         [Theory, AutoMoqData]
+        public async Task Company_WhenCalledWithIp_ShouldThrowBadRequestException(
+            [Frozen] Mock<IHttpClient> httpClient,
+            string apiKey)
+        {
+            // Arrange
+            httpClient
+                .Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>()))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.BadRequest));
+
+            var sut = new IpDataClient(apiKey, httpClient.Object);
+            Func<Task> act = async () => { await sut.Company("1.1.1.1").ConfigureAwait(false); };
+
+            // Act/Assert
+            await act.Should()
+                .ThrowAsync<BadRequestException>()
+                .ConfigureAwait(false);
+        }
+
+        [Theory, AutoMoqData]
+        public async Task Company_WhenCalledWithIp_ShouldThrowForbiddenException(
+            [Frozen] Mock<IHttpClient> httpClient,
+            string apiKey)
+        {
+            // Arrange
+            httpClient
+                .Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>()))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Forbidden));
+
+            var sut = new IpDataClient(apiKey, httpClient.Object);
+            Func<Task> act = async () => { await sut.Company("1.1.1.1").ConfigureAwait(false); };
+
+            // Act/Assert
+            await act.Should()
+                .ThrowAsync<ForbiddenException>()
+                .ConfigureAwait(false);
+        }
+
+        [Theory, AutoMoqData]
+        public async Task Company_WhenCalledWithIp_ShouldThrowUnauthorizedException(
+            [Frozen] Mock<IHttpClient> httpClient,
+            string apiKey)
+        {
+            // Arrange
+            httpClient
+                .Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>()))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.Unauthorized));
+
+            var sut = new IpDataClient(apiKey, httpClient.Object);
+            Func<Task> act = async () => { await sut.Company("1.1.1.1").ConfigureAwait(false); };
+
+            // Act/Assert
+            await act.Should()
+                .ThrowAsync<UnauthorizedException>()
+                .ConfigureAwait(false);
+        }
+
+        [Theory, AutoMoqData]
+        public async Task Company_WhenCalledWithIp_ShouldThrowApiException(
+            [Frozen] Mock<IHttpClient> httpClient,
+            string apiKey)
+        {
+            // Arrange
+            httpClient
+                .Setup(x => x.SendAsync(It.IsAny<HttpRequestMessage>()))
+                .ReturnsAsync(new HttpResponseMessage(0));
+
+            var sut = new IpDataClient(apiKey, httpClient.Object);
+            Func<Task> act = async () => { await sut.Company("1.1.1.1").ConfigureAwait(false); };
+
+            // Act/Assert
+            await act.Should()
+                .ThrowAsync<ApiException>()
+                .ConfigureAwait(false);
+        }
+
+        [Theory, AutoMoqData]
         public async Task Carrier_WhenCalledWithIp_ShouldThrowBadRequestException(
             [Frozen] Mock<IHttpClient> httpClient,
             string apiKey)


### PR DESCRIPTION
## Proposed changes

This PR adds support for the Company endpoint to the IpData client and refactors the `ApiUrls` helper class to support custom base URLs (e.g., for the EU endpoint).

### Key changes:

1. **New Company endpoint**: Added `Company(string ip)` method to `IIpDataClient` and `IpDataClient` to fetch company information for a given IP address, including name, domain, network, and type.

2. **ApiUrls refactoring**: Converted `ApiUrls` from a static class to an instance-based class with constructor support for custom base URLs. This enables users to specify alternative endpoints like `https://eu-api.ipdata.co`.

3. **IpDataClient constructors**: Added new constructor overload `IpDataClient(string apiKey, Uri baseUrl)` to allow specifying a custom base URL while using the default HTTP client.

4. **Model enhancements**:
   - Added `CompanyInfo` model with properties for Name, Domain, Network, and Type
   - Added `BlocklistInfo` model for threat blocklist information
   - Extended `Threat` model with `IsIcloudRelay`, `IsDatacenter`, and `Blocklists` properties
   - Extended `IpInfo` model with `RegionType`, `Carrier`, `Company`, and `Status` properties
   - Extended `Language` model with `Code` property

5. **Documentation**: Updated README with Company endpoint example and EU endpoint usage instructions.

6. **Target framework**: Updated sample and test projects to .NET 8.0.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have added tests that prove my feature works (Company endpoint tests and ApiUrls instantiation tests)
- [x] I have added necessary documentation (README updated with Company endpoint and EU endpoint examples)
- [x] Existing unit tests updated to work with refactored ApiUrls class

## Test coverage

- Added 4 new unit tests for Company endpoint error handling (BadRequest, Forbidden, Unauthorized, ApiException)
- Added 2 new unit tests for ApiUrls Company method and custom base URL support
- Added 1 test verifying default constructor uses correct base URL
- Added serialization tests for CompanyInfo model
- All existing tests updated to instantiate ApiUrls rather than calling static methods

https://claude.ai/code/session_01GqyDyB2zrpxr1ZVw8vFVg3